### PR TITLE
Further changes for v. 2.01

### DIFF
--- a/openstore/AppDetailsPage.qml
+++ b/openstore/AppDetailsPage.qml
@@ -84,6 +84,23 @@ Page {
             }
 
             ListItem {
+                visible: app.isLocalVersionSideloaded
+                height: sideloadedLayout.height
+                ListItemLayout {
+                    id: sideloadedLayout
+                    subtitle.text: i18n.tr("The installed version of this app doesn't come from the OpenStore server. You can install the latest stable update by tapping the button below.")
+                    subtitle.maximumLineCount: Number.MAX_VALUE
+                    subtitle.wrapMode: Text.WordWrap
+
+                    Icon {
+                        SlotsLayout.position: SlotsLayout.Leading
+                        width: units.gu(4); height: width
+                        name: "info"
+                    }
+                }
+            }
+
+            ListItem {
                 height: units.gu(8)
 
                 RowLayout {
@@ -98,7 +115,7 @@ Page {
                         Layout.maximumWidth: buttonsRow.width > units.gu(60) ? units.gu(24) : buttonsRow.width
                         text: app.installed ? i18n.tr("Upgrade") : i18n.tr("Install")
                         visible: !app.installed || (app.installed && app.updateAvailable)
-                        color: UbuntuColors.green
+                        color: app.isLocalVersionSideloaded ? theme.palette.normal.foreground : UbuntuColors.green
                         onClicked: app.install()
                     }
 

--- a/openstore/CategoriesTab.qml
+++ b/openstore/CategoriesTab.qml
@@ -89,6 +89,9 @@ AdaptivePageLayout {
                 id: categoryView
                 anchors.fill: parent
 
+                property int __currentTmpIndex
+                currentIndex: rootItem.columns > 1 ? __currentTmpIndex : -1
+
                 // WORKAROUND: Fix for wrong grid unit size
                 Component.onCompleted: root.flickable_responsive_scroll_fix(categoryView)
 
@@ -96,7 +99,7 @@ AdaptivePageLayout {
                 delegate: ListItem {
                     divider.anchors.leftMargin: units.gu(6.5)
                     onClicked: {
-                        categoryView.currentIndex = model.index
+                        categoryView.__currentTmpIndex = model.index
                         rootItem.categoryClicked(model.name, model.id)
                     }
                     ListItemLayout {
@@ -113,13 +116,6 @@ AdaptivePageLayout {
                         ProgressionSlot {}
                     }
                 }
-            }
-        }
-
-        Connections {
-            target: rootItem
-            onColumnsChanged: {
-                categoryView.highlightItem.visible = (rootItem.columns > 1 ? true : false)
             }
         }
     }

--- a/openstore/CategoriesTab.qml
+++ b/openstore/CategoriesTab.qml
@@ -115,6 +115,13 @@ AdaptivePageLayout {
                 }
             }
         }
+
+        Connections {
+            target: rootItem
+            onColumnsChanged: {
+                categoryView.highlightItem.visible = (rootItem.columns > 1 ? true : false)
+            }
+        }
     }
 }
 

--- a/openstore/Components/EmptyState.qml
+++ b/openstore/Components/EmptyState.qml
@@ -35,9 +35,11 @@ Column {
     property alias title: emptyLabel.text
     property alias subTitle: emptySublabel.text
 
+    property alias controlComponent: controlLoader.sourceComponent
+
     Item {
         width: childrenRect.width
-        height: childrenRect.height + units.gu(2)
+        height: childrenRect.height
         Icon {
             id: emptyIcon
             height: visible ? units.gu(10) : 0
@@ -70,5 +72,9 @@ Column {
 
         elide: Text.ElideRight
         wrapMode: Text.WordWrap
+    }
+
+    Loader {
+        id: controlLoader
     }
 }

--- a/openstore/Components/SectionDivider.qml
+++ b/openstore/Components/SectionDivider.qml
@@ -31,15 +31,4 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
         }
     }
-
-    Rectangle {
-        anchors {
-            left: parent.left
-            right: parent.right
-            bottom: parent.bottom
-        }
-
-        height: units.dp(1)
-        color: "#cdcdcd"
-    }
 }

--- a/openstore/DiscoverTab.qml
+++ b/openstore/DiscoverTab.qml
@@ -162,6 +162,15 @@ Page {
                             }
                         }
                     }
+
+                    // WORKAROUND: appStoreUpdateAlert visibility is toggled after the whole page is layouted.
+                    // This may result in the "Discover" tab being slightly scrolled down at start-up.
+                    Connections {
+                        target: appStoreUpdateAlert
+                        onVisibleChanged: {
+                            view.positionViewAtBeginning()
+                        }
+                    }
                 }
             }
 
@@ -180,15 +189,6 @@ Page {
                     return discoverModel.getPackage(i)
                 }
             }
-        }
-    }
-
-    // WORKAROUND: appStoreUpdateAlert visibility is toggled after the whole page is layouted.
-    // This may result in the "Discover" tab being slightly scrolled down at start-up.
-    Connections {
-        target: appStoreUpdateAlert
-        onVisibleChanged: {
-            view.positionViewAtBeginning()
         }
     }
 }

--- a/openstore/Main.qml
+++ b/openstore/Main.qml
@@ -105,6 +105,11 @@ MainView {
         }
     }
 
+    Connections {
+        target: OpenStoreNetworkManager
+        onNetworkAccessibleChanged: console.log("[OpenStoreNetworkManager] Is network accessible?", OpenStoreNetworkManager.networkAccessible)
+    }
+
     Settings {
         id: settings
         property bool firstStart: true
@@ -121,6 +126,36 @@ MainView {
 
     Components.BottomEdgePageStack {
         id: bottomEdgeStack
+    }
+
+    Loader {
+        anchors.fill: parent
+        z: Number.MAX_VALUE
+        active: !OpenStoreNetworkManager.networkAccessible
+        sourceComponent: MouseArea {
+            // Capture all mouse/touch events beneath 'mainContainer'
+            anchors.fill: parent
+            onWheel: wheel.accepted = true  // wheel events are not captured by default
+
+            Rectangle {
+                anchors.fill: parent
+                color: root.backgroundColor
+
+                Components.EmptyState {
+                    title: i18n.tr("Slow or no internet connection available")
+                    subTitle: i18n.tr("Please check your internet settings and try again")
+                    iconName: "airplane-mode"
+
+                    controlComponent: Button {
+                        color: UbuntuColors.green
+                        text: i18n.tr("Close OpenStore")
+                        onClicked: Qt.quit()
+                    }
+
+                    anchors.centerIn: parent
+                }
+            }
+        }
     }
 
     Component {

--- a/openstore/Main.qml
+++ b/openstore/Main.qml
@@ -128,6 +128,7 @@ MainView {
         id: bottomEdgeStack
     }
 
+    /*
     Loader {
         anchors.fill: parent
         z: Number.MAX_VALUE
@@ -157,6 +158,7 @@ MainView {
             }
         }
     }
+    */
 
     Component {
         id: filteredAppPageComponent

--- a/openstore/main.cpp
+++ b/openstore/main.cpp
@@ -26,6 +26,12 @@
 #include "packagesmodel.h"
 #include "discovermodel.h"
 #include "packagescache.h"
+#include "openstorenetworkmanager.h"
+
+static QObject *registerNetworkManagerSingleton (QQmlEngine * /*engine*/, QJSEngine * /*scriptEngine*/)
+{
+    return OpenStoreNetworkManager::instance();
+}
 
 static QObject *registerPlatformIntegrationSingleton (QQmlEngine * /*engine*/, QJSEngine * /*scriptEngine*/)
 {
@@ -43,6 +49,7 @@ int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
 
+    qmlRegisterSingletonType<OpenStoreNetworkManager>("OpenStore", 1, 0, "OpenStoreNetworkManager", registerNetworkManagerSingleton);
     qmlRegisterSingletonType<PlatformIntegration>("OpenStore", 1, 0, "PlatformIntegration", registerPlatformIntegrationSingleton);
     qmlRegisterSingletonType<PackagesCache>("OpenStore", 1, 0, "PackagesCache", registerPackagesCacheSingleton);
     qmlRegisterUncreatableType<ClickInstaller>("OpenStore", 1, 0, "ClickInstaller", "Access ClickInstall from the PlatformIntegration singleton");

--- a/openstore/openstorenetworkmanager.h
+++ b/openstore/openstorenetworkmanager.h
@@ -15,13 +15,13 @@ struct OpenStoreReply {
 class OpenStoreNetworkManager : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QNetworkAccessManager::NetworkAccessibility networkAccessible READ networkAccessible NOTIFY networkAccessibleChanged)
+    Q_PROPERTY(bool networkAccessible READ networkAccessible NOTIFY networkAccessibleChanged)
 
 public:   
     explicit OpenStoreNetworkManager();
     static OpenStoreNetworkManager* instance();
 
-    QNetworkAccessManager::NetworkAccessibility networkAccessible() const { return m_manager->networkAccessible(); }
+    bool networkAccessible() const { return m_manager->networkAccessible() != QNetworkAccessManager::NotAccessible; }
 
     QString generateNewSignature() const;
 

--- a/openstore/package.h
+++ b/openstore/package.h
@@ -23,6 +23,7 @@ class PackageItem: public QObject
     Q_PROPERTY(QString installedVersionString READ installedVersionString NOTIFY updated)
     Q_PROPERTY(int revision READ revision NOTIFY updated)
     Q_PROPERTY(int installedRevision READ installedRevision NOTIFY updated)
+    Q_PROPERTY(bool isLocalVersionSideloaded READ isLocalVersionSideloaded NOTIFY updated)
     Q_PROPERTY(QString packageUrl READ packageUrl NOTIFY updated)
     Q_PROPERTY(QString source READ source NOTIFY updated)
     Q_PROPERTY(QString license READ license NOTIFY updated)
@@ -74,6 +75,7 @@ public:
     QString installedVersionString() const { return m_installedVersion; }
     int revision() const { return m_revision; }
     int installedRevision() const { return m_installedRevision; }
+    bool isLocalVersionSideloaded() const { return !m_installedVersion.isEmpty() && (m_installedRevision < 1); }
     QString packageUrl() const { return m_packageUrl; }
     QString source() const { return m_source; }
     QString license() const { return m_license; }

--- a/openstore/packagesmodel.cpp
+++ b/openstore/packagesmodel.cpp
@@ -18,6 +18,7 @@
 PackagesModel::PackagesModel(QAbstractListModel * parent)
     : QAbstractListModel(parent)
     , m_ready(false)
+    , m_appStoreUpdateAvailable(false)
 {
     connect(PlatformIntegration::instance(), &PlatformIntegration::updated, this, &PackagesModel::refresh);
     connect(PackagesCache::instance(), &PackagesCache::updatingCacheChanged, this, &PackagesModel::refresh);

--- a/openstore/searchmodel.cpp
+++ b/openstore/searchmodel.cpp
@@ -88,8 +88,6 @@ void SearchModel::update()
 bool SearchModel::canFetchMore(const QModelIndex &parent) const
 {
     Q_UNUSED(parent)
-    qDebug() << m_fetchedAll;
-
     return m_queryUrl.isValid() ? false : bool(!m_fetchedAll);
 }
 


### PR DESCRIPTION
- Add alert for sideloaded apps
- Fixed OpenStore update alert visibility check
- Fixed blue highlight in Categories tab being visible on phones
- Removed noisy app output
- Fixed default value for m_appStoreUpdateAvailable
- Check for availability of internet and handle offline state (it's disabled for now, as it doesn't work well at startup)
- Removed bottom line from SectionDivider

TODO: Update .pot
TODO: Bump app version

