### PR TITLE
 Fixed download counter (i.e. wrong field has been defaulted) + fixed redirected download urls

### DIFF
--- a/manifest.json.in
+++ b/manifest.json.in
@@ -11,7 +11,7 @@
             "content-hub": "openstore/openstore-contenthub.json"
         }
     },
-    "version": "2.01",
+    "version": "2.02",
     "maintainer": "OpenStore Team <openstore-team@lists.launchpad.net>",
     "framework": "ubuntu-sdk-15.04.6"
 }

--- a/openstore/package.cpp
+++ b/openstore/package.cpp
@@ -72,9 +72,11 @@ void PackageItem::fillData(const QVariantMap &json)
     m_name = json.value("name").toString();
     m_author = json.value("author").toString();
 
-    m_packageUrl = json.value("package").toString();    // Used by the 'discover' API
+    m_packageUrl = json.value("download").toString();
     if (m_packageUrl.isEmpty()) {
-        m_packageUrl = json.value("download").toString();
+        // Fallback when "download" is not returned
+        // This might be the case for the 'discover' API
+        m_packageUrl = json.value("package").toString();
     }
 
     m_source = json.value("source").toString();


### PR DESCRIPTION
Reverted to old code from Michael. Isolated the routine which handles download abortion.