### PR TITLE
Add sourceSize for better svg ratering

### DIFF
--- a/openstore/AppDetailsPage.qml
+++ b/openstore/AppDetailsPage.qml
@@ -77,6 +77,8 @@ Page {
                         image: Image {
                             height: parent.height
                             width: parent.width
+                            sourceSize.width: parent.width
+                            sourceSize.height: parent.height
                             source: app ? app.icon : ""
                         }
                     }

--- a/openstore/Components/PackageListItem.qml
+++ b/openstore/Components/PackageListItem.qml
@@ -20,6 +20,8 @@ ListItem {
             aspect: UbuntuShape.Flat
             image: Image {
                 source: rootItem.appItem.icon
+                sourceSize.width: parent.width
+				sourceSize.height: parent.height
                 height: parent.height
                 width: parent.width
             }

--- a/openstore/Components/PackageTile.qml
+++ b/openstore/Components/PackageTile.qml
@@ -15,6 +15,8 @@ AbstractButton {
             sourceFillMode: UbuntuShape.PreserveAspectFit
             source: Image {
                 source: rootItem.appItem.icon
+                sourceSize.width: parent.width
+				sourceSize.height: parent.height
             }
         }
 

--- a/openstore/InstalledAppsTab.qml
+++ b/openstore/InstalledAppsTab.qml
@@ -82,7 +82,11 @@ Page {
                         SlotsLayout.position: SlotsLayout.Leading
                         width: units.gu(4); height: width
                         aspect: UbuntuShape.Flat
-                        image: Image { source: model.icon }
+                        image: Image { 
+							sourceSize.width: parent.width
+                            sourceSize.height: parent.height
+							source: model.icon 
+						}
                     }
 
                     ProgressionSlot {}


### PR DESCRIPTION
SVG icons doesn't look blurry when sourceSize if applyed (as the same size of UbuntuShape)